### PR TITLE
Upgrade Azure SDK to 1.3.0 to fix the missing NSG issue after VMSS image update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.6</version>
+        <version>2.11</version>
     </parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
+
     <artifactId>azure-vmss</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
@@ -23,8 +23,9 @@
         <java.level>7</java.level>
         <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
         <guava.version>19.0</guava.version>
-        <azuresdk.version>1.1.0</azuresdk.version>
-        <azure-credentials.version>1.3</azure-credentials.version>
+        <jackson.version>2.7.2</jackson.version>
+        <azuresdk.version>1.3.0</azuresdk.version>
+        <azure-credentials.version>1.3.1</azure-credentials.version>
         <azure-commons.version>0.1.5</azure-commons.version>
     </properties>
 
@@ -62,18 +63,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
@@ -98,29 +87,11 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>3.3.9</version>
-            <scope>provided</scope>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>3.3.9</version>
-            <scope>provided</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.19.1</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -167,6 +138,7 @@
                     <maskClasses>
                         com.microsoft.azure.management.
                         com.google.common.
+                        com.fasterxml.jackson.
                     </maskClasses>
                 </configuration>
             </plugin>

--- a/src/test/java/com/microsoft/jenkins/vmss/UpdateInstancesBuilderTest.java
+++ b/src/test/java/com/microsoft/jenkins/vmss/UpdateInstancesBuilderTest.java
@@ -7,14 +7,8 @@
 package com.microsoft.jenkins.vmss;
 
 import com.microsoft.azure.management.Azure;
-import com.microsoft.azure.management.compute.VirtualMachineScaleSet;
-import com.microsoft.azure.management.compute.VirtualMachineScaleSetStorageProfile;
-import com.microsoft.azure.management.compute.VirtualMachineScaleSetVMProfile;
 import com.microsoft.azure.management.compute.VirtualMachineScaleSets;
-import com.microsoft.azure.management.compute.implementation.ImageReferenceInner;
-import com.microsoft.azure.management.compute.implementation.VirtualMachineScaleSetInner;
 import com.microsoft.azure.management.compute.implementation.VirtualMachineScaleSetsInner;
-import edu.emory.mathcs.backport.java.util.Arrays;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -27,13 +21,11 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,6 +71,6 @@ public class UpdateInstancesBuilderTest {
         final ArgumentCaptor<List<String>> instanceIdsArg = ArgumentCaptor.forClass(List.class);
         verify(azure.virtualMachineScaleSets().inner()).updateInstances(
                 eq("rg"), eq("name"), instanceIdsArg.capture());
-        Assert.assertEquals(Arrays.asList(new String[]{"1", "2", "3", "4", "5"}), instanceIdsArg.getValue());
+        Assert.assertEquals(Arrays.asList("1", "2", "3", "4", "5"), instanceIdsArg.getValue());
     }
 }

--- a/src/test/java/com/microsoft/jenkins/vmss/util/AzureUtilsTest.java
+++ b/src/test/java/com/microsoft/jenkins/vmss/util/AzureUtilsTest.java
@@ -15,7 +15,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class AzureUtilsTest {
 
@@ -29,7 +30,7 @@ public class AzureUtilsTest {
     }
 
     @Test
-    public void fromServicePrincipal() throws NoSuchFieldException, IllegalAccessException {
+    public void fromServicePrincipal() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         final AzureCredentials.ServicePrincipal sp = new AzureCredentials.ServicePrincipal(
                 "sub",
                 "client",
@@ -42,13 +43,13 @@ public class AzureUtilsTest {
         );
         final ApplicationTokenCredentials token = AzureUtils.fromServicePrincipal(sp);
         final AzureEnvironment env = token.environment();
-        final Field secretField = token.getClass().getDeclaredField("secret");
-        secretField.setAccessible(true);
-        Assert.assertEquals("secret", (String)secretField.get(token));
+        final Method secretMethod = token.getClass().getDeclaredMethod("clientSecret");
+        secretMethod.setAccessible(true);
+        Assert.assertEquals("secret", secretMethod.invoke(token));
         Assert.assertEquals("client", token.clientId());
         Assert.assertEquals("tenant", token.domain());
         Assert.assertEquals("management", env.managementEndpoint());
-        Assert.assertEquals("auth", env.activeDirectoryEndpoint());
+        Assert.assertEquals("auth/", env.activeDirectoryEndpoint());
         Assert.assertEquals("rm", env.resourceManagerEndpoint());
         Assert.assertEquals("graph", env.graphEndpoint());
     }


### PR DESCRIPTION
Azure SDK 1.3.0 added the `networkSecurityGroup` (and `enableAcceleratedNetworking`, `dnsSettings`) to the `VirtualMachineScaleSetNetworkConfigurationInner` class.

Before this, when we update the vmss with the inner class, the NSG information will not be included in the request, so Azure discards the NSG configuration, which sets the NSG to null after an image update.

This PR upgrades the SDK to 1.3.0, and cleaned the plugin dependencies.